### PR TITLE
Small fixes & ErsatzTV support

### DIFF
--- a/src/components/ChannelList.tsx
+++ b/src/components/ChannelList.tsx
@@ -58,7 +58,7 @@ export const ChannelList = ({ channels, selectedChannel, onSelectChannel, panelS
                         <img
                           src={channel.logo}
                           alt={channel.name}
-                          className="w-8 h-8 rounded object-cover"
+                          className="w-8 h-8 rounded object-contain"
                         />
                       ) : (
                         <div className="w-8 h-8 rounded bg-secondary flex items-center justify-center">

--- a/src/components/EPGView.tsx
+++ b/src/components/EPGView.tsx
@@ -178,7 +178,7 @@ export const EPGView = ({ programs, channelName, isIdle, onPosterClick, selected
                     {program.category && (
                       <>
                         <span>•</span>
-                        <span>{program.category}</span>
+                        <span>{typeof program.category === 'string' ? program.category : program.category.map((c) => c["#text"]).join(", ")}</span>
                       </>
                     )}
                   </div>

--- a/src/components/EPGView.tsx
+++ b/src/components/EPGView.tsx
@@ -119,6 +119,12 @@ export const EPGView = ({ programs, channelName, isIdle, onPosterClick, selected
                 <div className="flex items-center gap-2 text-sm text-foreground/80 mb-2">
                   <Clock className="w-4 h-4" />
                   <span>{formatDuration(currentProgram.start, currentProgram.end)}</span>
+                  {currentProgram.category && (
+                    <>
+                      <span>•</span>
+                      <span>{typeof currentProgram.category === 'string' ? currentProgram.category : currentProgram.category.map((c) => c["#text"]).join(", ")}</span>
+                    </>
+                  )}
                 </div>
                 <Star 
                   className={`absolute bottom-3 right-3 w-4 h-4 cursor-pointer ${isFavorite(currentProgram) ? 'fill-white text-white opacity-50' : 'text-muted-foreground'}`} 

--- a/src/types/iptv.ts
+++ b/src/types/iptv.ts
@@ -13,7 +13,7 @@ export interface Program {
   description?: string;
   start: Date;
   end: Date;
-  category?: string;
+  category?: string | { "@_lang": string; "#text": string }[];
   icon?: string;
   image?: string;
   episodeNum?: string;

--- a/src/utils/xmltvParser.ts
+++ b/src/utils/xmltvParser.ts
@@ -13,7 +13,8 @@ export const parseXMLTV = (content: string): EPGData => {
   const parser = new XMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: '@_',
-    processEntities: true, // Now process entities since we escaped bare &
+    processEntities: true, // Process HTML entities like &#246; -> ö
+    htmlEntities: true, // Enable HTML entity processing
   });
   
   try {


### PR DESCRIPTION
- Before the channel logos were cut if they weren't exactly square:

  before:
  <img width="134" height="271" alt="Screenshot 2025-11-06 at 10 48 10" src="https://github.com/user-attachments/assets/ac260275-2c51-48fa-a2a3-918ae62ce331" />
now:
  <img width="223" height="263" alt="Screenshot 2025-11-06 at 10 47 35" src="https://github.com/user-attachments/assets/77864f63-bd04-42ce-8ad9-09e61d39466c" />

- Supporting the categories of ErsatzTV (#58)
- Showing the categories also on the currently playing program
- Now the "umlaute" are shown correctly:

  before: 
  <img width="373" height="96" alt="Screenshot 2025-11-06 at 10 50 10" src="https://github.com/user-attachments/assets/4599f3f6-add5-478b-bde0-2666ea9b8b57" />
  now:
  <img width="446" height="113" alt="Screenshot 2025-11-06 at 10 50 37" src="https://github.com/user-attachments/assets/d7a3d344-c265-42c7-8420-526c98adcbbd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Channel logos now display with optimized scaling for improved appearance.

* **Bug Fixes**
  * Program categories are now displayed consistently across current and upcoming program views.
  * Special characters in program data are now properly processed and rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->